### PR TITLE
Update decode.go

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -41,7 +41,7 @@ func iszlib(buf []byte) bool {
 func ischunk(buf []byte) bool {
 	for i, c := range buf {
 		switch {
-		case '0' >= c && c <= '9':
+		case '0' <= c && c <= '9':
 			continue
 		case 'a' <= c && c <= 'f':
 			continue

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,1 @@
+module github.com/jopik1/webarchive

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,1 @@
-module github.com/jopil1/webarchive
+module github.com/jopik1/webarchive

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,1 @@
-module github.com/richardlehane/webarchive
+module github.com/jopil1/webarchive

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,0 @@
-module github.com/jopik1/webarchive


### PR DESCRIPTION
Fixed typo

case '0' >= c && c <= '9':

 to 

case '0' <= c && c <= '9':

in 

func ischunk(buf []byte) bool